### PR TITLE
Add full meta to output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
         defaultPackage = self.packages.${system}.hydra-eval-jobs;
         devShell = defaultPackage.overrideAttrs (old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [
-            pkgs.python3.pkgs.pytest
+            (pkgs.python3.withPackages(ps: [
+              ps.pytest
+            ]))
           ];
         });
       });


### PR DESCRIPTION
While the current output may be sufficient for Hydra it's not enough for a more generically useful evaluator.

The encoding method isn't the most computationally efficient (it does a double encode/decode) but it was the way I could figure out how to do so without replicating code from the Nix code base.